### PR TITLE
Added zh_TW and zh_CN Language Files

### DIFF
--- a/language/zh_CN.json
+++ b/language/zh_CN.json
@@ -1,1 +1,35 @@
-{}
+{
+    "commands": {
+        "settings": {
+            "set": {
+                "suggestionChannel": {
+                    "no_textchannel": "建议用频道仅限文字频道（并且不能为公告用频道）",
+                    "success": "成功设定 {channel} 为建议用频道。"
+                },
+                "language": {
+                    "select_language": "请选择机器人所使用的语言。",
+                    "select_language_option": "设定 {language} 为机器人所使用的语言",
+                    "success": "成功设定 `{language}` 为机器人所使用的语言。"
+                },
+                "apikey": {
+                    "invalid_key": "无效的API网址或金钥。",
+                    "success": "成功设定API金钥。"
+                },
+                "authkey": {
+                    "success": "成功设定授权代码为 `{token}`，使用指令 `/webhookurl` 来获取新的Webhook网址。"
+                }
+            }
+        },
+        "suggest": {
+            "modal-title": "提出建议！",
+            "modal-question-1": "建议标题",
+            "modal-question-2": "建议内容",
+            "success": "我们已收到您的建议，造访 {link} 来检视它。"
+        },
+        "webhookurl": {
+            "generate_key_first": "您必须先使用指令 `/settings set authkey` 来生成授权代码。",
+            "success": "Webhook网址是 `{url}`，\n请使用它来当作建议模组的Discord Webhook网址。"
+        }
+    },
+    "permission_required": "抱歉！您没有 {permission} 权限。"
+}

--- a/language/zh_TW.json
+++ b/language/zh_TW.json
@@ -1,0 +1,35 @@
+{
+    "commands": {
+        "settings": {
+            "set": {
+                "suggestionChannel": {
+                    "no_textchannel": "建議用頻道僅限文字頻道（並且不能為公告用頻道）",
+                    "success": "成功設定 {channel} 為建議用頻道。"
+                },
+                "language": {
+                    "select_language": "請選擇機器人所使用的語言。",
+                    "select_language_option": "設定 {language} 為機器人所使用的語言",
+                    "success": "成功設定 `{language}` 為機器人所使用的語言。"
+                },
+                "apikey": {
+                    "invalid_key": "無效的API網址或金鑰。",
+                    "success": "成功設定API金鑰。"
+                },
+                "authkey": {
+                    "success": "成功設定授權代碼為 `{token}`，使用指令 `/webhookurl` 來獲取新的Webhook網址。"
+                }
+            }
+        },
+        "suggest": {
+            "modal-title": "提出建議！",
+            "modal-question-1": "建議標題",
+            "modal-question-2": "建議內容",
+            "success": "我們已收到您的建議，造訪 {link} 來檢視它。"
+        },
+        "webhookurl": {
+            "generate_key_first": "您必須先使用指令 `/settings set authkey` 來生成授權代碼。",
+            "success": "Webhook網址是 `{url}`，\n請使用它來當作建議模組的Discord Webhook網址。"
+        }
+    },
+    "permission_required": "抱歉！您沒有 {permission} 權限。"
+}

--- a/src/handlers/Logger.ts
+++ b/src/handlers/Logger.ts
@@ -6,13 +6,8 @@ export default class Logger {
     //
 
     public static makeSize(string: string, length: number): string {
-        if (string.length >= length) return string.slice(0, 5);
-
-        while (string.length < length) {
-            string += " ";
-        }
-
-        return string;
+        if (string.length >= length) return string.slice(0, length);
+        return string + " ".repeat(length - string.length);
     }
 
     public static getLineAndChar(

--- a/src/managers/LanguageManager.ts
+++ b/src/managers/LanguageManager.ts
@@ -29,6 +29,7 @@ export default class LanguageManager {
 		"Russian": "ru_RU",
 		"Slovak": "sk_SK",
 		"Turkish": "tr_TR",
+		"Chinese(Traditional)": "zh_TW",
 		"Chinese(Simplified)": "zh_CN",
 		"Portuguese": "pt_BR"
 	}


### PR DESCRIPTION
Language **`zh_CN`** was **already registered** but no **translations** were added,
this pull request simply **updated `zh_CN`** and **added `zh_TW`** languages.

Note that I attempted to register a new language **`zh_TW`** by adding it to **[`LanguageManager.ts`](https://github.com/supercrafter100/Nameless-Suggestions-Discord-Bot/blob/master/src/managers/LanguageManager.ts)**.
I'm **not quite sure** whether or not this is the correct way to do so,
please **review it** and **request changes** if needed before merging this pull request.