### PR TITLE
Suggestion title needs to be minimum of 6 characters

### DIFF
--- a/src/commands/suggest.command.ts
+++ b/src/commands/suggest.command.ts
@@ -36,7 +36,7 @@ export default class extends Command {
         titleInput.setLabel(modalQuestion1Str!);
         titleInput.setStyle("SHORT");
         titleInput.setRequired(true);
-        titleInput.setMinLength(3)
+        titleInput.setMinLength(6)
 
         const descriptionInput = new TextInputComponent();
         descriptionInput.setCustomId("suggest-description");


### PR DESCRIPTION
This fixes bot thinking forever when user entered title that had less than 6 characters