### PR TITLE
Fix sent comment detection logic

### DIFF
--- a/src/managers/SuggestionHandler.ts
+++ b/src/managers/SuggestionHandler.ts
@@ -10,7 +10,7 @@ import LanguageManager from "./LanguageManager";
 
 export default class {
 
-    private sentThreadMessages = new Set<Number>();
+    private sentThreadMessages = new Set<string>();
 
     constructor(private readonly bot: Bot) {}
 
@@ -67,8 +67,8 @@ export default class {
             return;
         }
 
-        if (this.sentThreadMessages.has(commentInfo.commentId)) {
-            this.sentThreadMessages.delete(commentInfo.commentId);
+        if (this.sentThreadMessages.has(`${suggestion.apiData.id}-${commentInfo.commentId}`)) {
+            this.sentThreadMessages.delete(`${suggestion.apiData.id}-${commentInfo.commentId}`);
             return;
         }
         
@@ -142,7 +142,7 @@ export default class {
                 }, 5000);
             }            
         } else {
-            this.sentThreadMessages.add(response.comment_id);
+            this.sentThreadMessages.add(`${suggestionInfo.id}-${response.comment_id}`);
         }
     }
 

--- a/src/managers/SuggestionHandler.ts
+++ b/src/managers/SuggestionHandler.ts
@@ -10,7 +10,7 @@ import LanguageManager from "./LanguageManager";
 
 export default class {
 
-    private lastSentThreadMessage = new Collection<string, string>();
+    private sentThreadMessages = new Set<Number>();
 
     constructor(private readonly bot: Bot) {}
 
@@ -62,17 +62,14 @@ export default class {
         });
     }
 
-    public async createComment(suggestion: SuggestionClass, guildInfo: Guild, commentInfo: { author: string, description: string, avatar: string }) {  
+    public async createComment(suggestion: SuggestionClass, guildInfo: Guild, commentInfo: { author: string, description: string, avatar: string, commentId: number }) {  
         if (!suggestion.apiData) {
             return;
         }
 
-        if (this.lastSentThreadMessage.has(suggestion.apiData.id.toString())) {
-            const content = this.lastSentThreadMessage.get(suggestion.apiData.id.toString())!;
-            if (commentInfo.description.startsWith(content)) {
-                return;
-            }
-            this.lastSentThreadMessage.delete(suggestion.apiData.id.toString()); // Only unset if a new comment has been sent
+        if (this.sentThreadMessages.has(commentInfo.commentId)) {
+            this.sentThreadMessages.delete(commentInfo.commentId);
+            return;
         }
         
         const dbSuggestion = await Suggestion.findOne({ where: { suggestionId: suggestion.apiData.id, guildId: guildInfo.id }});
@@ -127,11 +124,9 @@ export default class {
         
         const content = msg.content;
         const authorId = msg.author.id;
-        this.lastSentThreadMessage.set(suggestionInfo.suggestionId.toString(), content); // Save before sending to the site
         
         const response = await this.bot.suggestionsApi.sendComment(suggestionInfo.suggestionId, msg.guildId!, content, authorId);
         if (response.error == "nameless:cannot_find_user") {
-            this.lastSentThreadMessage.delete(suggestionInfo.suggestionId.toString());
             await msg.delete();
             
             const str = await LanguageManager.getString(msg.guildId!, "suggestionHandler.cannot_find_user");
@@ -146,6 +141,8 @@ export default class {
                     sent.delete();
                 }, 5000);
             }            
+        } else {
+            this.sentThreadMessages.add(response.comment_id);
         }
     }
 
@@ -253,7 +250,8 @@ export default class {
                 await this.createComment(suggestion, guildData, {
                     avatar: `https://avatars.dicebear.com/api/initials/${comment.user.username}.png?size=128`,
                     description: comment.content,
-                    author: comment.user.username
+                    author: comment.user.username,
+                    commentId: comment.id
                 });
             }
         }

--- a/src/managers/SuggestionHandler.ts
+++ b/src/managers/SuggestionHandler.ts
@@ -10,7 +10,7 @@ import LanguageManager from "./LanguageManager";
 
 export default class {
 
-    private sentThreadMessages = new Set<string>();
+    private sentThreadMessages = new Set<`${string}-${string}-${string}`>();
 
     constructor(private readonly bot: Bot) {}
 
@@ -67,8 +67,8 @@ export default class {
             return;
         }
 
-        if (this.sentThreadMessages.has(`${suggestion.apiData.id}-${commentInfo.commentId}`)) {
-            this.sentThreadMessages.delete(`${suggestion.apiData.id}-${commentInfo.commentId}`);
+        if (this.sentThreadMessages.has(this.createThreadMessageCompoundId(guildInfo.id, suggestion.apiData.id, commentInfo.commentId))) {
+            this.sentThreadMessages.delete(this.createThreadMessageCompoundId(guildInfo.id, suggestion.apiData.id, commentInfo.commentId));
             return;
         }
         
@@ -142,7 +142,7 @@ export default class {
                 }, 5000);
             }            
         } else {
-            this.sentThreadMessages.add(`${suggestionInfo.id}-${response.comment_id}`);
+            this.sentThreadMessages.add(this.createThreadMessageCompoundId(msg.guildId!, suggestionInfo.suggestionId, response.comment_id));
         }
     }
 
@@ -256,5 +256,9 @@ export default class {
             }
         }
         this.bot.logger.debug("Finished sending all suggestions from API.");
+    }
+
+    private createThreadMessageCompoundId(guildId: string, suggestionId: string, commentId: number): `${string}-${string}-${string}` {
+        return `${guildId}-${suggestionId}-${commentId}`
     }
 }

--- a/src/managers/SuggestionHandler.ts
+++ b/src/managers/SuggestionHandler.ts
@@ -67,8 +67,8 @@ export default class {
             return;
         }
 
-        if (this.sentThreadMessages.has(this.createThreadMessageCompoundId(guildInfo.id, suggestion.apiData.id, commentInfo.commentId))) {
-            this.sentThreadMessages.delete(this.createThreadMessageCompoundId(guildInfo.id, suggestion.apiData.id, commentInfo.commentId));
+        if (this.sentThreadMessages.has(this.createThreadMessageCompositeId(guildInfo.id, suggestion.apiData.id, commentInfo.commentId))) {
+            this.sentThreadMessages.delete(this.createThreadMessageCompositeId(guildInfo.id, suggestion.apiData.id, commentInfo.commentId));
             return;
         }
         
@@ -142,7 +142,7 @@ export default class {
                 }, 5000);
             }            
         } else {
-            this.sentThreadMessages.add(this.createThreadMessageCompoundId(msg.guildId!, suggestionInfo.suggestionId, response.comment_id));
+            this.sentThreadMessages.add(this.createThreadMessageCompositeId(msg.guildId!, suggestionInfo.suggestionId, response.comment_id));
         }
     }
 
@@ -258,7 +258,7 @@ export default class {
         this.bot.logger.debug("Finished sending all suggestions from API.");
     }
 
-    private createThreadMessageCompoundId(guildId: string, suggestionId: string, commentId: number): `${string}-${string}-${string}` {
+    private createThreadMessageCompositeId(guildId: string, suggestionId: string, commentId: number): `${string}-${string}-${string}` {
         return `${guildId}-${suggestionId}-${commentId}`
     }
 }

--- a/src/managers/Webserver.ts
+++ b/src/managers/Webserver.ts
@@ -81,6 +81,7 @@ export default class {
                 description: commentInfo?.content,
                 author,
                 avatar: req.body.avatar_url,
+                commentId: commentInfo.id
             });
         }
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -42,7 +42,7 @@ export interface ApiListSuggestion {
 }
 
 export interface ApiComment {
-    id: string;
+    id: number;
     user: {
         id: string;
         username: string;


### PR DESCRIPTION
Currently the bot uses the suggestion ID and the content to try and block comments sent through Discord from being sent again in Discord once the webhook event is received which is problematic (delay can cause issues etc.). Another issue noted with the current system is that new lines are not handled correctly and so the check is bypassed.

This PR switches to saving the comment ID in a set when a comment is created through the API and then when a comment is received checking if it exists in the set, and if so not sending the message in to the thread and then removing the comment ID in the set.